### PR TITLE
16.0 qa [IMP] account_statement_report: semáforo de 2 colores y reporte por cliente

### DIFF
--- a/account_statement_report/__init__.py
+++ b/account_statement_report/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_statement_report/__manifest__.py
+++ b/account_statement_report/__manifest__.py
@@ -1,0 +1,31 @@
+{
+    "name": "Estado de cuenta de clientes",
+    "summary": "Reporte de antigüedad de saldos por vendedor y por cliente (PDF y Excel)",
+    "description": """
+        Asistente para generar el estado de cuenta de clientes (facturas con
+        saldo pendiente) con días de atraso a una fecha de corte elegida.
+
+        - Reporte de todos los vendedores, con sus clientes agrupados.
+        - Reporte de un vendedor en particular, con sus clientes agrupados.
+        - Salida en PDF (QWeb) y en Excel (xlsx).
+        - Seguridad: un vendedor solo puede generar el reporte de sus propios
+          clientes; quienes pertenecen al grupo de gestión ven a todos.
+        - Envío recurrente por correo (diario/semanal) a cada vendedor con sus
+          clientes, y reporte global a un administrador.
+    """,
+    "author": "Alvaro Gutierrez",
+    "category": "Accounting/Reporting",
+    "version": "16.0.2.0.0",
+    "depends": ["account", "mail"],
+    "data": [
+        "security/account_statement_security.xml",
+        "security/ir.model.access.csv",
+        "data/account_statement_data.xml",
+        "report/account_statement_report.xml",
+        "views/account_statement_wizard_views.xml",
+        "views/account_statement_config_views.xml",
+    ],
+    "license": "LGPL-3",
+    "installable": True,
+    "application": False,
+}

--- a/account_statement_report/data/account_statement_data.xml
+++ b/account_statement_report/data/account_statement_data.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Plantilla de correo para el envío recurrente -->
+    <record id="mail_template_account_statement" model="mail.template">
+        <field name="name">Estado de cuenta de clientes (envío recurrente)</field>
+        <field name="model_id" ref="model_account_statement_wizard"/>
+        <field name="subject">Estado de cuenta de clientes — {{ object.salesperson_id.name or 'Todos los vendedores' }} — corte {{ object.statement_date }}</field>
+        <field name="email_from">{{ (object.env.company.email or user.email_formatted) }}</field>
+        <field name="body_html" type="html">
+            <div style="margin:0;padding:0;font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#333;">
+                <p>Hola <t t-out="object.salesperson_id.name or 'equipo'"></t>,</p>
+                <p>
+                    Adjunto encontrarás el <strong>estado de cuenta de clientes</strong>
+                    con fecha de corte <strong t-out="object.statement_date or ''"></strong>,
+                    en formato PDF y Excel.
+                </p>
+                <p style="color:#555;">
+                    Incluye las facturas con saldo pendiente, sus días de atraso y los
+                    subtotales por cliente.
+                </p>
+                <p style="margin-top:18px;color:#888;font-size:12px;">
+                    Mensaje automático · <t t-out="object.env.company.name or ''"></t>
+                </p>
+            </div>
+        </field>
+        <field name="lang">{{ object.env.lang }}</field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+
+    <!-- Acción planificada (apagada por defecto; corre diario y filtra semanal en código) -->
+    <record id="ir_cron_send_statements" model="ir.cron">
+        <field name="name">Estado de cuenta: envío recurrente a vendedores</field>
+        <field name="model_id" ref="model_account_statement_wizard"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_send_statements()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="active" eval="False"/>
+        <field name="nextcall" eval="(DateTime.now().replace(hour=13, minute=0, second=0) + timedelta(days=1))"/>
+    </record>
+
+</odoo>

--- a/account_statement_report/models/__init__.py
+++ b/account_statement_report/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_statement_wizard
+from . import account_statement_config

--- a/account_statement_report/models/account_statement_config.py
+++ b/account_statement_report/models/account_statement_config.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from odoo import api, fields, models
+
+CRON_XMLID = "account_statement_report.ir_cron_send_statements"
+PARAM_FREQ = "account_statement_report.frequency"
+PARAM_WEEKDAY = "account_statement_report.weekday"
+PARAM_ADMIN = "account_statement_report.admin_user_id"
+PARAM_SALES = "account_statement_report.salesperson_ids"
+
+
+class AccountStatementConfig(models.TransientModel):
+    _name = "account.statement.config"
+    _description = "Configuración del envío recurrente del estado de cuenta"
+
+    auto_send = fields.Boolean(
+        string="Activar envío recurrente",
+        help="Activa la acción planificada que envía por correo el estado de "
+        "cuenta a cada vendedor (PDF + Excel).",
+    )
+    frequency = fields.Selection(
+        [("daily", "Diario"), ("weekly", "Semanal")],
+        string="Frecuencia",
+        required=True,
+        default="weekly",
+    )
+    weekday = fields.Selection(
+        [
+            ("0", "Lunes"),
+            ("1", "Martes"),
+            ("2", "Miércoles"),
+            ("3", "Jueves"),
+            ("4", "Viernes"),
+            ("5", "Sábado"),
+            ("6", "Domingo"),
+        ],
+        string="Día de envío",
+        default="0",
+        help="Día de la semana en que se envía cuando la frecuencia es semanal.",
+    )
+    admin_user_id = fields.Many2one(
+        "res.users",
+        string="Administrador (reporte global)",
+        domain="[('share', '=', False)]",
+        help="Recibe un correo aparte con el estado de cuenta de TODOS los "
+        "vendedores. Vacío = no se envía el reporte global.",
+    )
+    salesperson_ids = fields.Many2many(
+        "res.users",
+        string="Vendedores a incluir",
+        domain="[('share', '=', False)]",
+        help="Vendedores que reciben su propio reporte. Vacío = todos los "
+        "usuarios internos activos con correo.",
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        Param = self.env["ir.config_parameter"].sudo()
+        cron = self.env.ref(CRON_XMLID, raise_if_not_found=False)
+        admin_id = Param.get_param(PARAM_ADMIN, "")
+        sales_raw = Param.get_param(PARAM_SALES, "")
+        sales_ids = [int(i) for i in sales_raw.split(",") if i.strip().isdigit()]
+        res.update(
+            auto_send=bool(cron and cron.active),
+            frequency=Param.get_param(PARAM_FREQ, "weekly"),
+            weekday=Param.get_param(PARAM_WEEKDAY, "0"),
+            admin_user_id=int(admin_id) if admin_id.isdigit() else False,
+            salesperson_ids=[(6, 0, sales_ids)],
+        )
+        return res
+
+    def action_save(self):
+        self.ensure_one()
+        Param = self.env["ir.config_parameter"].sudo()
+        cron = self.env.ref(CRON_XMLID, raise_if_not_found=False)
+        if cron:
+            cron.active = self.auto_send
+        Param.set_param(PARAM_FREQ, self.frequency)
+        Param.set_param(PARAM_WEEKDAY, self.weekday or "0")
+        Param.set_param(
+            PARAM_ADMIN, str(self.admin_user_id.id) if self.admin_user_id else ""
+        )
+        Param.set_param(
+            PARAM_SALES, ",".join(str(i) for i in self.salesperson_ids.ids)
+        )
+        return {"type": "ir.actions.act_window_close"}

--- a/account_statement_report/models/account_statement_wizard.py
+++ b/account_statement_report/models/account_statement_wizard.py
@@ -17,9 +17,9 @@ except ImportError:  # pragma: no cover
 
 GROUP_ALL = "account_statement_report.group_account_statement_all"
 
-# Semáforo de atraso: (límite superior de días, color de fondo, etiqueta)
+# Semáforo de atraso: (límite superior de días, color de fondo)
 AGING_COLORS = (
-    (0, "#C6EFCE"),    # al corriente / por vencer (días <= 0)
+    (0, ""),           # al corriente / por vencer (días <= 0): sin color
     (30, "#FFEB9C"),   # 1 - 30 días
     (60, "#F8CBAD"),   # 31 - 60 días
     (None, "#FFC7CE"),  # más de 60 días
@@ -81,16 +81,15 @@ class AccountStatementWizard(models.TransientModel):
         required=True,
         default="pdf",
     )
-    can_see_all = fields.Boolean(compute="_compute_can_see_all")
+    # Valor por defecto (no computado) para que esté disponible al abrir el
+    # asistente, en default_get, antes de renderizar el formulario. Así los
+    # attrs de la vista no "parpadean" hasta después de pulsar el botón.
+    can_see_all = fields.Boolean(
+        default=lambda self: self.env.user.has_group(GROUP_ALL),
+    )
 
     xlsx_file = fields.Binary(string="Archivo Excel", readonly=True)
     xlsx_filename = fields.Char(readonly=True)
-
-    @api.depends_context("uid")
-    def _compute_can_see_all(self):
-        can = self.env.user.has_group(GROUP_ALL)
-        for wiz in self:
-            wiz.can_see_all = can
 
     @api.model
     def default_get(self, fields_list):
@@ -306,12 +305,13 @@ class AccountStatementWizard(models.TransientModel):
         total_money = workbook.add_format(
             {"bold": True, "border": 1, "num_format": money_fmt, "bg_color": "#FFE699"}
         )
-        # Semáforo de atraso: un formato por color.
+        # Semáforo de atraso: un formato por color (los días <= 0 van sin relleno).
         aging_fmts = {
             color: workbook.add_format(
                 {"border": 1, "align": "center", "bg_color": color}
             )
             for _limit, color in AGING_COLORS
+            if color
         }
 
         sheet = workbook.add_worksheet("Estado de cuenta")
@@ -338,7 +338,7 @@ class AccountStatementWizard(models.TransientModel):
             "CLIENTE",
             "FECHA FACT",
             "FECHA VENC.",
-            "FECHA ESTADO DE CUENTA",
+            "FECHA DE CORTE",
             "DIAS DE ATRASO",
             "MONTO",
         ]
@@ -363,7 +363,7 @@ class AccountStatementWizard(models.TransientModel):
                     row += 1
                 sheet.merge_range(
                     row, 0, row, 5,
-                    "Subtotal %s" % client["name"], cli_sub_lbl,
+                    "Total %s" % client["name"], cli_sub_lbl,
                 )
                 sheet.write_number(row, 6, client["subtotal"], cli_sub_money)
                 row += 1

--- a/account_statement_report/models/account_statement_wizard.py
+++ b/account_statement_report/models/account_statement_wizard.py
@@ -20,9 +20,8 @@ GROUP_ALL = "account_statement_report.group_account_statement_all"
 # Semáforo de atraso: (límite superior de días, color de fondo)
 AGING_COLORS = (
     (0, ""),           # al corriente / por vencer (días <= 0): sin color
-    (30, "#FFEB9C"),   # 1 - 30 días
-    (60, "#F8CBAD"),   # 31 - 60 días
-    (None, "#FFC7CE"),  # más de 60 días
+    (14, "#FFEB9C"),   # 1 - 14 días: amarillo
+    (None, "#FFC7CE"),  # 15 días o más: rojo
 )
 
 
@@ -43,6 +42,14 @@ class AccountStatementWizard(models.TransientModel):
         default=fields.Date.context_today,
         help="Fecha de corte usada para calcular los días de atraso.",
     )
+    group_by = fields.Selection(
+        [("salesperson", "Por vendedor"), ("partner", "Por cliente")],
+        string="Agrupar",
+        required=True,
+        default="salesperson",
+        help="Define el agrupamiento principal del reporte: por vendedor "
+        "(y dentro por cliente) o por cliente (y dentro por vendedor).",
+    )
     report_scope = fields.Selection(
         [("all", "Todos los vendedores"), ("single", "Un vendedor")],
         string="Alcance",
@@ -53,6 +60,11 @@ class AccountStatementWizard(models.TransientModel):
         "res.users",
         string="Vendedor",
         domain="[('share', '=', False)]",
+    )
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Cliente",
+        help="Opcional: limita el reporte a un único cliente.",
     )
     only_overdue = fields.Boolean(
         string="Solo facturas vencidas",
@@ -130,9 +142,14 @@ class AccountStatementWizard(models.TransientModel):
             domain.append(("invoice_user_id", "=", self.env.user.id))
         elif self.report_scope == "single" and self.salesperson_id:
             domain.append(("invoice_user_id", "=", self.salesperson_id.id))
-        return self.env["account.move"].search(
-            domain, order="invoice_user_id, partner_id, invoice_date, name"
+        if self.partner_id:
+            domain.append(("partner_id", "=", self.partner_id.id))
+        order = (
+            "partner_id, invoice_user_id, invoice_date, name"
+            if self.group_by == "partner"
+            else "invoice_user_id, partner_id, invoice_date, name"
         )
+        return self.env["account.move"].search(domain, order=order)
 
     def _line_sort_key(self):
         return {
@@ -145,6 +162,7 @@ class AccountStatementWizard(models.TransientModel):
         self.ensure_one()
         self._check_access_scope()
         cutoff = self.statement_date
+        by_partner = self.group_by == "partner"
         groups = OrderedDict()
         count = 0
         for move in self._get_moves():
@@ -155,21 +173,25 @@ class AccountStatementWizard(models.TransientModel):
             if self.min_overdue_days and days < self.min_overdue_days:
                 continue
             sp = move.invoice_user_id
-            group = groups.setdefault(
-                sp.id or 0,
-                {
-                    "name": sp.name or _("Sin vendedor"),
-                    "clients": OrderedDict(),
-                    "subtotal": 0.0,
-                },
-            )
             partner = move.partner_id
-            client = group["clients"].setdefault(
-                partner.id,
-                {"name": partner.name or "", "lines": [], "subtotal": 0.0},
+            # El nivel superior (group) y el inferior (subgrupo) se invierten
+            # según el agrupamiento elegido.
+            if by_partner:
+                top, top_name = partner, partner.name or ""
+                sub, sub_name = sp, (sp.name or _("Sin vendedor"))
+            else:
+                top, top_name = sp, (sp.name or _("Sin vendedor"))
+                sub, sub_name = partner, partner.name or ""
+            group = groups.setdefault(
+                top.id or 0,
+                {"name": top_name, "clients": OrderedDict(), "subtotal": 0.0},
+            )
+            subgroup = group["clients"].setdefault(
+                sub.id or 0,
+                {"name": sub_name, "lines": [], "subtotal": 0.0},
             )
             amount = move.amount_residual_signed
-            client["lines"].append(
+            subgroup["lines"].append(
                 {
                     "factura": move.name,
                     "fecha_fact": move.invoice_date,
@@ -180,14 +202,14 @@ class AccountStatementWizard(models.TransientModel):
                     "monto": amount,
                 }
             )
-            client["subtotal"] += amount
+            subgroup["subtotal"] += amount
             group["subtotal"] += amount
             count += 1
 
         sort_key = self._line_sort_key()
         for group in groups.values():
-            for client in group["clients"].values():
-                client["lines"].sort(key=sort_key)
+            for subgroup in group["clients"].values():
+                subgroup["lines"].sort(key=sort_key)
 
         total = sum(g["subtotal"] for g in groups.values())
         return {
@@ -197,6 +219,9 @@ class AccountStatementWizard(models.TransientModel):
             "user": self.env.user,
             "print_date": fields.Date.context_today(self),
             "scope": "single" if not self.can_see_all else self.report_scope,
+            "group_by": self.group_by,
+            "group_label": _("Cliente") if by_partner else _("Vendedor"),
+            "subgroup_label": _("Vendedor") if by_partner else _("Cliente"),
             "only_overdue": self.only_overdue,
             "min_overdue_days": self.min_overdue_days,
             "order_label": dict(
@@ -225,8 +250,13 @@ class AccountStatementWizard(models.TransientModel):
 
     def _report_basename(self):
         self.ensure_one()
-        who = self.salesperson_id.name if self.report_scope == "single" and self.salesperson_id else "Todos"
-        slug = "".join(c if c.isalnum() else "_" for c in who)
+        if self.partner_id:
+            who = self.partner_id.name
+        elif self.report_scope == "single" and self.salesperson_id:
+            who = self.salesperson_id.name
+        else:
+            who = "Todos"
+        slug = "".join(c if c.isalnum() else "_" for c in who or "")
         return "Estado_de_cuenta_%s_%s" % (slug, self.statement_date or "")
 
     def _render_xlsx_bytes(self, data=None):
@@ -335,13 +365,14 @@ class AccountStatementWizard(models.TransientModel):
 
         columns = [
             "FACTURA",
-            "CLIENTE",
+            (data.get("subgroup_label") or "Cliente").upper(),
             "FECHA FACT",
             "FECHA VENC.",
             "FECHA DE CORTE",
             "DIAS DE ATRASO",
             "MONTO",
         ]
+        group_label = data.get("group_label") or "Vendedor"
 
         for group in data["groups"]:
             sheet.merge_range(row, 0, row, 6, group["name"], sp_fmt)
@@ -369,7 +400,7 @@ class AccountStatementWizard(models.TransientModel):
                 row += 1
             sheet.merge_range(
                 row, 0, row, 5,
-                "Total vendedor %s" % group["name"], sp_sub_lbl,
+                "Total %s %s" % (group_label.lower(), group["name"]), sp_sub_lbl,
             )
             sheet.write_number(row, 6, group["subtotal"], sp_sub_money)
             row += 2

--- a/account_statement_report/models/account_statement_wizard.py
+++ b/account_statement_report/models/account_statement_wizard.py
@@ -1,0 +1,495 @@
+# -*- coding: utf-8 -*-
+import base64
+import datetime
+import io
+import logging
+from collections import OrderedDict
+
+from odoo import _, api, fields, models
+from odoo.exceptions import AccessError, UserError
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import xlsxwriter
+except ImportError:  # pragma: no cover
+    xlsxwriter = None
+
+GROUP_ALL = "account_statement_report.group_account_statement_all"
+
+# Semáforo de atraso: (límite superior de días, color de fondo, etiqueta)
+AGING_COLORS = (
+    (0, "#C6EFCE"),    # al corriente / por vencer (días <= 0)
+    (30, "#FFEB9C"),   # 1 - 30 días
+    (60, "#F8CBAD"),   # 31 - 60 días
+    (None, "#FFC7CE"),  # más de 60 días
+)
+
+
+def _aging_color(days):
+    for limit, color in AGING_COLORS:
+        if limit is None or days <= limit:
+            return color
+    return AGING_COLORS[-1][1]
+
+
+class AccountStatementWizard(models.TransientModel):
+    _name = "account.statement.wizard"
+    _description = "Asistente de estado de cuenta de clientes"
+
+    statement_date = fields.Date(
+        string="Fecha de estado de cuenta",
+        required=True,
+        default=fields.Date.context_today,
+        help="Fecha de corte usada para calcular los días de atraso.",
+    )
+    report_scope = fields.Selection(
+        [("all", "Todos los vendedores"), ("single", "Un vendedor")],
+        string="Alcance",
+        required=True,
+        default="all",
+    )
+    salesperson_id = fields.Many2one(
+        "res.users",
+        string="Vendedor",
+        domain="[('share', '=', False)]",
+    )
+    only_overdue = fields.Boolean(
+        string="Solo facturas vencidas",
+        help="Incluir únicamente facturas que ya pasaron su fecha de "
+        "vencimiento en la fecha de corte (días de atraso mayores a 0).",
+    )
+    min_overdue_days = fields.Integer(
+        string="Días de atraso mínimo",
+        default=0,
+        help="Mostrar solo facturas con al menos estos días de atraso. "
+        "Deja 0 para no filtrar por antigüedad.",
+    )
+    order_by = fields.Selection(
+        [
+            ("days_desc", "Días de atraso (mayor primero)"),
+            ("amount_desc", "Monto (mayor primero)"),
+            ("date", "Fecha de factura"),
+        ],
+        string="Ordenar por",
+        required=True,
+        default="days_desc",
+    )
+    output_format = fields.Selection(
+        [("pdf", "PDF"), ("xlsx", "Excel")],
+        string="Formato",
+        required=True,
+        default="pdf",
+    )
+    can_see_all = fields.Boolean(compute="_compute_can_see_all")
+
+    xlsx_file = fields.Binary(string="Archivo Excel", readonly=True)
+    xlsx_filename = fields.Char(readonly=True)
+
+    @api.depends_context("uid")
+    def _compute_can_see_all(self):
+        can = self.env.user.has_group(GROUP_ALL)
+        for wiz in self:
+            wiz.can_see_all = can
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if not self.env.user.has_group(GROUP_ALL):
+            res.update(report_scope="single", salesperson_id=self.env.user.id)
+        return res
+
+    @api.onchange("report_scope")
+    def _onchange_report_scope(self):
+        if self.report_scope == "single" and not self.salesperson_id:
+            self.salesperson_id = self.env.user
+
+    # ------------------------------------------------------------------
+    # Seguridad y obtención de datos
+    # ------------------------------------------------------------------
+    def _check_access_scope(self):
+        """Impide que un vendedor saque el reporte de otros vendedores/clientes."""
+        self.ensure_one()
+        if self.can_see_all:
+            return
+        if self.report_scope == "all" or (
+            self.salesperson_id and self.salesperson_id != self.env.user
+        ):
+            raise AccessError(
+                _("Solo puedes generar el estado de cuenta de tus propios clientes.")
+            )
+
+    def _get_moves(self):
+        self.ensure_one()
+        domain = [
+            ("move_type", "in", ("out_invoice", "out_refund")),
+            ("state", "=", "posted"),
+            ("amount_residual", ">", 0),
+        ]
+        if not self.can_see_all:
+            # Vendedor restringido: forzado a sus propias facturas.
+            domain.append(("invoice_user_id", "=", self.env.user.id))
+        elif self.report_scope == "single" and self.salesperson_id:
+            domain.append(("invoice_user_id", "=", self.salesperson_id.id))
+        return self.env["account.move"].search(
+            domain, order="invoice_user_id, partner_id, invoice_date, name"
+        )
+
+    def _line_sort_key(self):
+        return {
+            "days_desc": lambda l: (-l["dias"], -l["monto"]),
+            "amount_desc": lambda l: (-l["monto"], -l["dias"]),
+            "date": lambda l: (l["fecha_fact"] or datetime.date.min, l["factura"] or ""),
+        }[self.order_by]
+
+    def _build_report_data(self):
+        self.ensure_one()
+        self._check_access_scope()
+        cutoff = self.statement_date
+        groups = OrderedDict()
+        count = 0
+        for move in self._get_moves():
+            due = move.invoice_date_due
+            days = (cutoff - due).days if due else 0
+            if self.only_overdue and days <= 0:
+                continue
+            if self.min_overdue_days and days < self.min_overdue_days:
+                continue
+            sp = move.invoice_user_id
+            group = groups.setdefault(
+                sp.id or 0,
+                {
+                    "name": sp.name or _("Sin vendedor"),
+                    "clients": OrderedDict(),
+                    "subtotal": 0.0,
+                },
+            )
+            partner = move.partner_id
+            client = group["clients"].setdefault(
+                partner.id,
+                {"name": partner.name or "", "lines": [], "subtotal": 0.0},
+            )
+            amount = move.amount_residual_signed
+            client["lines"].append(
+                {
+                    "factura": move.name,
+                    "fecha_fact": move.invoice_date,
+                    "fecha_venc": due,
+                    "fecha_corte": cutoff,
+                    "dias": days,
+                    "color": _aging_color(days),
+                    "monto": amount,
+                }
+            )
+            client["subtotal"] += amount
+            group["subtotal"] += amount
+            count += 1
+
+        sort_key = self._line_sort_key()
+        for group in groups.values():
+            for client in group["clients"].values():
+                client["lines"].sort(key=sort_key)
+
+        total = sum(g["subtotal"] for g in groups.values())
+        return {
+            "company": self.env.company,
+            "currency": self.env.company.currency_id,
+            "cutoff": cutoff,
+            "user": self.env.user,
+            "print_date": fields.Date.context_today(self),
+            "scope": "single" if not self.can_see_all else self.report_scope,
+            "only_overdue": self.only_overdue,
+            "min_overdue_days": self.min_overdue_days,
+            "order_label": dict(
+                self._fields["order_by"]._description_selection(self.env)
+            ).get(self.order_by, ""),
+            "groups": list(groups.values()),
+            "total": total,
+            "invoice_count": count,
+        }
+
+    # ------------------------------------------------------------------
+    # Acciones
+    # ------------------------------------------------------------------
+    def action_generate(self):
+        self.ensure_one()
+        self._check_access_scope()
+        if self.output_format == "xlsx":
+            return self.action_generate_xlsx()
+        return self.action_generate_pdf()
+
+    def action_generate_pdf(self):
+        self.ensure_one()
+        return self.env.ref(
+            "account_statement_report.action_report_account_statement"
+        ).report_action(self)
+
+    def _report_basename(self):
+        self.ensure_one()
+        who = self.salesperson_id.name if self.report_scope == "single" and self.salesperson_id else "Todos"
+        slug = "".join(c if c.isalnum() else "_" for c in who)
+        return "Estado_de_cuenta_%s_%s" % (slug, self.statement_date or "")
+
+    def _render_xlsx_bytes(self, data=None):
+        """Devuelve los bytes del reporte en formato XLSX."""
+        self.ensure_one()
+        if xlsxwriter is None:
+            raise UserError(_("La librería xlsxwriter no está disponible en el servidor."))
+        if data is None:
+            data = self._build_report_data()
+        output = io.BytesIO()
+        workbook = xlsxwriter.Workbook(output, {"in_memory": True})
+        self._write_xlsx(workbook, data)
+        workbook.close()
+        output.seek(0)
+        return output.read()
+
+    def _render_pdf_bytes(self):
+        """Devuelve los bytes del reporte en formato PDF."""
+        self.ensure_one()
+        return self.env["ir.actions.report"]._render_qweb_pdf(
+            "account_statement_report.action_report_account_statement",
+            res_ids=self.ids,
+        )[0]
+
+    def action_generate_xlsx(self):
+        self.ensure_one()
+        filename = "%s.xlsx" % self._report_basename()
+        self.write(
+            {
+                "xlsx_file": base64.b64encode(self._render_xlsx_bytes()),
+                "xlsx_filename": filename,
+            }
+        )
+        return {
+            "type": "ir.actions.act_url",
+            "url": "/web/content/account.statement.wizard/%s/xlsx_file/%s?download=true"
+            % (self.id, filename),
+            "target": "self",
+        }
+
+    def _write_xlsx(self, workbook, data):
+        money_fmt = "$ #,##0.00"
+        title = workbook.add_format({"bold": True, "font_size": 14})
+        sub = workbook.add_format({"font_size": 10})
+        sp_fmt = workbook.add_format(
+            {"bold": True, "font_size": 11, "bg_color": "#D9E1F2"}
+        )
+        header = workbook.add_format(
+            {
+                "bold": True,
+                "align": "center",
+                "valign": "vcenter",
+                "text_wrap": True,
+                "bg_color": "#BFBFBF",
+                "border": 1,
+            }
+        )
+        cell = workbook.add_format({"border": 1})
+        cell_center = workbook.add_format({"border": 1, "align": "center"})
+        cell_money = workbook.add_format({"border": 1, "num_format": money_fmt})
+        cli_sub_lbl = workbook.add_format(
+            {"bold": True, "border": 1, "align": "right"}
+        )
+        cli_sub_money = workbook.add_format(
+            {"bold": True, "border": 1, "num_format": money_fmt}
+        )
+        sp_sub_lbl = workbook.add_format(
+            {"bold": True, "border": 1, "align": "right", "bg_color": "#D9E1F2"}
+        )
+        sp_sub_money = workbook.add_format(
+            {"bold": True, "border": 1, "num_format": money_fmt, "bg_color": "#D9E1F2"}
+        )
+        total_lbl = workbook.add_format(
+            {"bold": True, "border": 1, "align": "right", "bg_color": "#FFE699"}
+        )
+        total_money = workbook.add_format(
+            {"bold": True, "border": 1, "num_format": money_fmt, "bg_color": "#FFE699"}
+        )
+        # Semáforo de atraso: un formato por color.
+        aging_fmts = {
+            color: workbook.add_format(
+                {"border": 1, "align": "center", "bg_color": color}
+            )
+            for _limit, color in AGING_COLORS
+        }
+
+        sheet = workbook.add_worksheet("Estado de cuenta")
+        sheet.set_column("A:A", 12)
+        sheet.set_column("B:B", 38)
+        sheet.set_column("C:E", 14)
+        sheet.set_column("F:F", 11)
+        sheet.set_column("G:G", 16)
+
+        sheet.write(0, 0, "Estado de cuenta de clientes", title)
+        sheet.write(1, 0, data["company"].name or "", sub)
+        sheet.write(2, 0, "Fecha de corte: %s" % (data["cutoff"] or ""), sub)
+        filtros = []
+        if data.get("only_overdue"):
+            filtros.append("solo vencidas")
+        if data.get("min_overdue_days"):
+            filtros.append("atraso ≥ %s días" % data["min_overdue_days"])
+        filtros.append("orden: %s" % (data.get("order_label") or ""))
+        sheet.write(3, 0, "Filtros: %s" % " · ".join(filtros), sub)
+        row = 5
+
+        columns = [
+            "FACTURA",
+            "CLIENTE",
+            "FECHA FACT",
+            "FECHA VENC.",
+            "FECHA ESTADO DE CUENTA",
+            "DIAS DE ATRASO",
+            "MONTO",
+        ]
+
+        for group in data["groups"]:
+            sheet.merge_range(row, 0, row, 6, group["name"], sp_fmt)
+            row += 1
+            for col, label in enumerate(columns):
+                sheet.write(row, col, label, header)
+            row += 1
+            for client in group["clients"].values():
+                for line in client["lines"]:
+                    sheet.write(row, 0, line["factura"] or "", cell)
+                    sheet.write(row, 1, client["name"], cell)
+                    sheet.write(row, 2, self._d(line["fecha_fact"]), cell_center)
+                    sheet.write(row, 3, self._d(line["fecha_venc"]), cell_center)
+                    sheet.write(row, 4, self._d(line["fecha_corte"]), cell_center)
+                    sheet.write_number(
+                        row, 5, line["dias"], aging_fmts.get(line["color"], cell_center)
+                    )
+                    sheet.write_number(row, 6, line["monto"], cell_money)
+                    row += 1
+                sheet.merge_range(
+                    row, 0, row, 5,
+                    "Subtotal %s" % client["name"], cli_sub_lbl,
+                )
+                sheet.write_number(row, 6, client["subtotal"], cli_sub_money)
+                row += 1
+            sheet.merge_range(
+                row, 0, row, 5,
+                "Total vendedor %s" % group["name"], sp_sub_lbl,
+            )
+            sheet.write_number(row, 6, group["subtotal"], sp_sub_money)
+            row += 2
+
+        sheet.merge_range(row, 0, row, 5, "TOTAL GENERAL", total_lbl)
+        sheet.write_number(row, 6, data["total"], total_money)
+
+    @staticmethod
+    def _d(value):
+        return value.strftime("%Y-%m-%d") if value else ""
+
+    # ------------------------------------------------------------------
+    # Envío recurrente por correo (acción planificada)
+    # ------------------------------------------------------------------
+    def _statement_recipients(self):
+        """Vendedores a los que se les envía el reporte (según configuración)."""
+        Param = self.env["ir.config_parameter"].sudo()
+        ids_raw = Param.get_param("account_statement_report.salesperson_ids", "")
+        ids = [int(i) for i in ids_raw.split(",") if i.strip().isdigit()]
+        if ids:
+            users = self.env["res.users"].browse(ids).exists()
+        else:
+            users = self.env["res.users"].search(
+                [("share", "=", False), ("active", "=", True)]
+            )
+        return users.filtered(lambda u: u.email)
+
+    def _send_statement_email(self, wizard, data):
+        """Genera PDF + XLSX para un wizard y envía el correo con ambos adjuntos."""
+        if wizard.report_scope == "single" and wizard.salesperson_id:
+            email_to = wizard.salesperson_id.email
+        else:
+            email_to = wizard.env.context.get("statement_email_to")
+        if not email_to:
+            return False
+        template = self.env.ref(
+            "account_statement_report.mail_template_account_statement",
+            raise_if_not_found=False,
+        )
+        if not template:
+            return False
+        basename = wizard._report_basename()
+        attachments = self.env["ir.attachment"].create(
+            [
+                {
+                    "name": "%s.pdf" % basename,
+                    "datas": base64.b64encode(wizard._render_pdf_bytes()),
+                    "mimetype": "application/pdf",
+                },
+                {
+                    "name": "%s.xlsx" % basename,
+                    "datas": base64.b64encode(wizard._render_xlsx_bytes(data)),
+                    "mimetype": "application/vnd.openxmlformats-officedocument."
+                    "spreadsheetml.sheet",
+                },
+            ]
+        )
+        template.send_mail(
+            wizard.id,
+            force_send=True,
+            email_values={
+                "email_to": email_to,
+                "attachment_ids": [(6, 0, attachments.ids)],
+            },
+        )
+        return True
+
+    @api.model
+    def _cron_send_statements(self):
+        """Acción planificada: envía a cada vendedor su estado de cuenta (PDF+XLSX)
+        y, opcionalmente, un reporte global a un administrador."""
+        Param = self.env["ir.config_parameter"].sudo()
+        frequency = Param.get_param("account_statement_report.frequency", "weekly")
+        cutoff = fields.Date.context_today(self)
+        if frequency == "weekly":
+            weekday = int(Param.get_param("account_statement_report.weekday", "0") or 0)
+            if cutoff.weekday() != weekday:
+                return
+        Wizard = self.with_context(active_test=False)
+        sent = skipped = 0
+
+        # Un correo por vendedor con sus propios clientes.
+        for user in self._statement_recipients():
+            wiz = Wizard.create(
+                {
+                    "statement_date": cutoff,
+                    "report_scope": "single",
+                    "salesperson_id": user.id,
+                    "order_by": "days_desc",
+                }
+            )
+            data = wiz._build_report_data()
+            if self._send_statement_email(wiz, data):
+                sent += 1
+            else:
+                skipped += 1
+
+        # Reporte global para el administrador configurado.
+        admin_id = Param.get_param("account_statement_report.admin_user_id", "")
+        admin = (
+            self.env["res.users"].browse(int(admin_id)).exists()
+            if admin_id.isdigit()
+            else self.env["res.users"]
+        )
+        if admin and admin.email:
+            wiz = Wizard.create(
+                {
+                    "statement_date": cutoff,
+                    "report_scope": "all",
+                    "order_by": "days_desc",
+                }
+            )
+            data = wiz._build_report_data()
+            self._send_statement_email(
+                wiz.with_context(statement_email_to=admin.email), data
+            )
+            sent += 1
+
+        _logger.info(
+            "Estado de cuenta recurrente: %s correos enviados, %s omitidos (sin email).",
+            sent,
+            skipped,
+        )

--- a/account_statement_report/report/account_statement_report.xml
+++ b/account_statement_report/report/account_statement_report.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="paperformat_account_statement" model="report.paperformat">
+        <field name="name">Estado de cuenta (horizontal)</field>
+        <field name="default" eval="False"/>
+        <field name="format">A4</field>
+        <field name="orientation">Landscape</field>
+        <field name="margin_top">12</field>
+        <field name="margin_bottom">12</field>
+        <field name="margin_left">7</field>
+        <field name="margin_right">7</field>
+        <field name="header_line" eval="False"/>
+        <field name="header_spacing">8</field>
+        <field name="dpi">90</field>
+    </record>
+
+    <record id="action_report_account_statement" model="ir.actions.report">
+        <field name="name">Estado de cuenta de clientes</field>
+        <field name="model">account.statement.wizard</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">account_statement_report.report_account_statement</field>
+        <field name="report_file">account_statement_report.report_account_statement</field>
+        <field name="paperformat_id" ref="paperformat_account_statement"/>
+        <field name="print_report_name">'Estado de cuenta - %s' % (object.statement_date or '')</field>
+    </record>
+
+    <template id="report_account_statement">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="data" t-value="o._build_report_data()"/>
+                <t t-call="web.basic_layout">
+                    <div class="page" style="font-size: 12px;">
+
+                        <!-- ============ Encabezado ============ -->
+                        <div class="row mb-2">
+                            <div class="col-7">
+                                <img t-if="data['company'].logo"
+                                     t-att-src="image_data_uri(data['company'].logo)"
+                                     style="max-height: 55px; max-width: 240px;"
+                                     alt="Logo"/>
+                                <div class="mt-1" style="font-size: 11px; color:#444;">
+                                    <strong t-out="data['company'].name"/>
+                                    <span t-if="data['company'].vat"> · RFC: <span t-out="data['company'].vat"/></span>
+                                </div>
+                            </div>
+                            <div class="col-5 text-end">
+                                <h3 class="mb-1" style="color:#1f3864;">Estado de cuenta de clientes</h3>
+                                <table class="table table-sm table-borderless mb-0"
+                                       style="font-size: 11px;">
+                                    <tr>
+                                        <td class="text-end fw-bold py-0" style="width:55%;">Fecha de corte:</td>
+                                        <td class="text-end py-0"><span t-out="data['cutoff']"/></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="text-end fw-bold py-0">Facturas:</td>
+                                        <td class="text-end py-0"><span t-out="data['invoice_count']"/></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="text-end fw-bold py-0">Generado por:</td>
+                                        <td class="text-end py-0">
+                                            <span t-out="data['user'].name"/> · <span t-out="data['print_date']"/>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </div>
+
+                        <!-- Filtros aplicados + leyenda del semáforo -->
+                        <div class="row mb-3" style="font-size: 10px;">
+                            <div class="col-7">
+                                <span class="fw-bold">Filtros:</span>
+                                <span t-if="data['only_overdue']" class="badge bg-secondary">Solo vencidas</span>
+                                <span t-if="data['min_overdue_days']" class="badge bg-secondary">
+                                    Atraso ≥ <span t-out="data['min_overdue_days']"/> días
+                                </span>
+                                <span class="badge bg-light text-dark border">Orden: <span t-out="data['order_label']"/></span>
+                            </div>
+                            <div class="col-5 text-end">
+                                <span class="fw-bold">Atraso:</span>
+                                <span class="px-2" style="background-color:#C6EFCE;">≤ 0</span>
+                                <span class="px-2" style="background-color:#FFEB9C;">1-30</span>
+                                <span class="px-2" style="background-color:#F8CBAD;">31-60</span>
+                                <span class="px-2" style="background-color:#FFC7CE;">+60</span>
+                            </div>
+                        </div>
+
+                        <!-- ============ Un bloque por vendedor ============ -->
+                        <t t-foreach="data['groups']" t-as="g">
+                            <div t-attf-style="page-break-before: #{'always' if not g_first else 'auto'};">
+                                <h4 class="mt-2 mb-1 p-1"
+                                    style="background-color:#1f3864; color:white; font-size: 13px;">
+                                    Vendedor: <span t-out="g['name']"/>
+                                </h4>
+                                <table class="table table-sm table-bordered mb-1">
+                                    <thead>
+                                        <tr class="text-center" style="background-color:#D9E1F2;">
+                                            <th>FACTURA</th>
+                                            <th>CLIENTE</th>
+                                            <th>FECHA FACT</th>
+                                            <th>FECHA VENC.</th>
+                                            <th>FECHA EDO. CUENTA</th>
+                                            <th>DÍAS DE ATRASO</th>
+                                            <th class="text-end">MONTO</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <t t-foreach="g['clients'].values()" t-as="c">
+                                            <t t-foreach="c['lines']" t-as="l">
+                                                <tr>
+                                                    <td t-out="l['factura']"/>
+                                                    <td t-out="c['name']"/>
+                                                    <td class="text-center" t-out="l['fecha_fact']"/>
+                                                    <td class="text-center" t-out="l['fecha_venc']"/>
+                                                    <td class="text-center" t-out="l['fecha_corte']"/>
+                                                    <td class="text-center fw-bold"
+                                                        t-attf-style="background-color:#{l['color']};"
+                                                        t-out="l['dias']"/>
+                                                    <td class="text-end">
+                                                        <span t-out="l['monto']"
+                                                              t-options="{'widget': 'monetary', 'display_currency': data['currency']}"/>
+                                                    </td>
+                                                </tr>
+                                            </t>
+                                            <tr class="fw-bold" style="background-color:#F2F2F2;">
+                                                <td colspan="6" class="text-end">
+                                                    Subtotal <span t-out="c['name']"/>
+                                                </td>
+                                                <td class="text-end">
+                                                    <span t-out="c['subtotal']"
+                                                          t-options="{'widget': 'monetary', 'display_currency': data['currency']}"/>
+                                                </td>
+                                            </tr>
+                                        </t>
+                                        <tr class="fw-bold" style="background-color:#D9E1F2;">
+                                            <td colspan="6" class="text-end">
+                                                Total vendedor <span t-out="g['name']"/>
+                                            </td>
+                                            <td class="text-end">
+                                                <span t-out="g['subtotal']"
+                                                      t-options="{'widget': 'monetary', 'display_currency': data['currency']}"/>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </t>
+
+                        <!-- ============ Total general ============ -->
+                        <table class="table table-sm mt-2">
+                            <tr class="fw-bold" style="background-color:#FFE699; font-size: 13px;">
+                                <td class="text-end">TOTAL GENERAL</td>
+                                <td class="text-end" style="width:18%;">
+                                    <span t-out="data['total']"
+                                          t-options="{'widget': 'monetary', 'display_currency': data['currency']}"/>
+                                </td>
+                            </tr>
+                        </table>
+
+                        <p t-if="not data['groups']" class="text-center text-muted mt-4">
+                            No se encontraron facturas con saldo pendiente para los filtros seleccionados.
+                        </p>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+
+</odoo>

--- a/account_statement_report/report/account_statement_report.xml
+++ b/account_statement_report/report/account_statement_report.xml
@@ -81,9 +81,8 @@
                             </div>
                             <div class="col-5 text-end">
                                 <span class="fw-bold">Atraso:</span>
-                                <span class="px-2" style="background-color:#FFEB9C;">1-30</span>
-                                <span class="px-2" style="background-color:#F8CBAD;">31-60</span>
-                                <span class="px-2" style="background-color:#FFC7CE;">+60</span>
+                                <span class="px-2" style="background-color:#FFEB9C;">1-14 días</span>
+                                <span class="px-2" style="background-color:#FFC7CE;">15 días o más</span>
                             </div>
                         </div>
 
@@ -92,13 +91,13 @@
                             <div t-attf-style="page-break-before: #{'always' if not g_first else 'auto'};">
                                 <h4 class="mt-2 mb-1 p-1"
                                     style="background-color:#1f3864; color:white; font-size: 13px;">
-                                    Vendedor: <span t-out="g['name']"/>
+                                    <span t-out="data['group_label']"/>: <span t-out="g['name']"/>
                                 </h4>
                                 <table class="table table-sm table-bordered mb-1" style="width:100%;">
                                     <thead>
                                         <tr class="text-center" style="background-color:#D9E1F2;">
                                             <th>FACTURA</th>
-                                            <th>CLIENTE</th>
+                                            <th><span t-out="data['subgroup_label'].upper()"/></th>
                                             <th>FECHA FACT</th>
                                             <th>FECHA VENC.</th>
                                             <th>FECHA DE CORTE</th>
@@ -136,7 +135,7 @@
                                         </t>
                                         <tr class="fw-bold" style="background-color:#D9E1F2;">
                                             <td colspan="6" class="text-end">
-                                                Total vendedor <span t-out="g['name']"/>
+                                                Total <span t-out="data['group_label'].lower()"/> <span t-out="g['name']"/>
                                             </td>
                                             <td class="text-end">
                                                 <span t-out="g['subtotal']"

--- a/account_statement_report/report/account_statement_report.xml
+++ b/account_statement_report/report/account_statement_report.xml
@@ -26,6 +26,9 @@
     </record>
 
     <template id="report_account_statement">
+        <!-- full_width => el <body> usa .container-fluid (100%) en vez de .container
+             (max-width fijo), necesario para que el contenido llene la hoja horizontal. -->
+        <t t-set="full_width" t-value="True"/>
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-set="data" t-value="o._build_report_data()"/>
@@ -78,7 +81,6 @@
                             </div>
                             <div class="col-5 text-end">
                                 <span class="fw-bold">Atraso:</span>
-                                <span class="px-2" style="background-color:#C6EFCE;">≤ 0</span>
                                 <span class="px-2" style="background-color:#FFEB9C;">1-30</span>
                                 <span class="px-2" style="background-color:#F8CBAD;">31-60</span>
                                 <span class="px-2" style="background-color:#FFC7CE;">+60</span>
@@ -92,14 +94,14 @@
                                     style="background-color:#1f3864; color:white; font-size: 13px;">
                                     Vendedor: <span t-out="g['name']"/>
                                 </h4>
-                                <table class="table table-sm table-bordered mb-1">
+                                <table class="table table-sm table-bordered mb-1" style="width:100%;">
                                     <thead>
                                         <tr class="text-center" style="background-color:#D9E1F2;">
                                             <th>FACTURA</th>
                                             <th>CLIENTE</th>
                                             <th>FECHA FACT</th>
                                             <th>FECHA VENC.</th>
-                                            <th>FECHA EDO. CUENTA</th>
+                                            <th>FECHA DE CORTE</th>
                                             <th>DÍAS DE ATRASO</th>
                                             <th class="text-end">MONTO</th>
                                         </tr>
@@ -114,7 +116,7 @@
                                                     <td class="text-center" t-out="l['fecha_venc']"/>
                                                     <td class="text-center" t-out="l['fecha_corte']"/>
                                                     <td class="text-center fw-bold"
-                                                        t-attf-style="background-color:#{l['color']};"
+                                                        t-attf-style="#{('background-color:' + l['color'] + ';') if l['color'] else ''}"
                                                         t-out="l['dias']"/>
                                                     <td class="text-end">
                                                         <span t-out="l['monto']"
@@ -124,7 +126,7 @@
                                             </t>
                                             <tr class="fw-bold" style="background-color:#F2F2F2;">
                                                 <td colspan="6" class="text-end">
-                                                    Subtotal <span t-out="c['name']"/>
+                                                    Total <span t-out="c['name']"/>
                                                 </td>
                                                 <td class="text-end">
                                                     <span t-out="c['subtotal']"
@@ -147,7 +149,7 @@
                         </t>
 
                         <!-- ============ Total general ============ -->
-                        <table class="table table-sm mt-2">
+                        <table class="table table-sm mt-2" style="width:100%;">
                             <tr class="fw-bold" style="background-color:#FFE699; font-size: 13px;">
                                 <td class="text-end">TOTAL GENERAL</td>
                                 <td class="text-end" style="width:18%;">

--- a/account_statement_report/security/account_statement_security.xml
+++ b/account_statement_report/security/account_statement_security.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="0">
+
+    <record id="group_account_statement_all" model="res.groups">
+        <field name="name">Estado de cuenta: ver todos los vendedores</field>
+        <field name="category_id" ref="base.module_category_accounting_accounting"/>
+        <field name="comment">
+            Permite generar el estado de cuenta de todos los vendedores y clientes.
+            Sin este grupo, el usuario solo puede generar el reporte de sus
+            propios clientes.
+        </field>
+    </record>
+
+    <!-- Los responsables de contabilidad ven a todos los vendedores. -->
+    <record id="account.group_account_manager" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('account_statement_report.group_account_statement_all'))]"/>
+    </record>
+
+</odoo>

--- a/account_statement_report/security/ir.model.access.csv
+++ b/account_statement_report/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_statement_wizard_user,account.statement.wizard.user,model_account_statement_wizard,base.group_user,1,1,1,1
+access_account_statement_config_manager,account.statement.config.manager,model_account_statement_config,account_statement_report.group_account_statement_all,1,1,1,1

--- a/account_statement_report/views/account_statement_config_views.xml
+++ b/account_statement_report/views/account_statement_config_views.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_statement_config_form" model="ir.ui.view">
+        <field name="name">account.statement.config.form</field>
+        <field name="model">account.statement.config</field>
+        <field name="arch" type="xml">
+            <form string="Envío recurrente del estado de cuenta">
+                <div class="oe_title mb-3">
+                    <h2 style="color:#1f3864;">
+                        <i class="fa fa-envelope-o me-2"/>Envío recurrente del estado de cuenta
+                    </h2>
+                    <p class="text-muted">
+                        Envía por correo, de forma automática, el estado de cuenta a cada
+                        vendedor (PDF + Excel). Requiere un servidor de correo saliente configurado.
+                    </p>
+                </div>
+                <group>
+                    <group string="Programación" name="prog">
+                        <field name="auto_send"/>
+                        <field name="frequency"/>
+                        <field name="weekday"
+                               attrs="{'invisible': [('frequency', '!=', 'weekly')]}"/>
+                    </group>
+                    <group string="Destinatarios" name="dest">
+                        <field name="salesperson_ids" widget="many2many_tags"
+                               options="{'no_create': True}"
+                               placeholder="Vacío = todos los vendedores activos con correo"/>
+                        <field name="admin_user_id"
+                               options="{'no_create': True, 'no_open': True}"/>
+                    </group>
+                </group>
+                <footer>
+                    <button name="action_save" string="Guardar"
+                            type="object" class="btn-primary"/>
+                    <button string="Cancelar" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_account_statement_config" model="ir.actions.act_window">
+        <field name="name">Envío recurrente del estado de cuenta</field>
+        <field name="res_model">account.statement.config</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_account_statement_config"
+              name="Envío recurrente del estado de cuenta"
+              parent="account.menu_finance_configuration"
+              action="action_account_statement_config"
+              sequence="99"/>
+
+</odoo>

--- a/account_statement_report/views/account_statement_wizard_views.xml
+++ b/account_statement_report/views/account_statement_wizard_views.xml
@@ -19,6 +19,7 @@
                 <group>
                     <group string="Alcance" name="alcance">
                         <field name="statement_date"/>
+                        <field name="group_by" widget="radio"/>
                         <field name="report_scope" widget="radio"
                                attrs="{'invisible': [('can_see_all', '=', False)], 'readonly': [('can_see_all', '=', False)]}"/>
                         <div class="text-muted"
@@ -28,6 +29,8 @@
                         <field name="salesperson_id"
                                options="{'no_create': True, 'no_open': True}"
                                attrs="{'invisible': [('report_scope', '!=', 'single')], 'required': [('report_scope', '=', 'single')], 'readonly': [('can_see_all', '=', False)]}"/>
+                        <field name="partner_id"
+                               options="{'no_create': True, 'no_open': True}"/>
                     </group>
                     <group string="Filtros" name="filtros">
                         <field name="only_overdue"/>

--- a/account_statement_report/views/account_statement_wizard_views.xml
+++ b/account_statement_report/views/account_statement_wizard_views.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_statement_wizard_form" model="ir.ui.view">
+        <field name="name">account.statement.wizard.form</field>
+        <field name="model">account.statement.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Estado de cuenta de clientes">
+                <field name="can_see_all" invisible="1"/>
+                <div class="oe_title mb-3">
+                    <h2 style="color:#1f3864;">
+                        <i class="fa fa-file-text-o me-2"/>Estado de cuenta de clientes
+                    </h2>
+                    <p class="text-muted">
+                        Genera la antigüedad de saldos de clientes (facturas con saldo
+                        pendiente) a una fecha de corte, en PDF o Excel.
+                    </p>
+                </div>
+                <group>
+                    <group string="Alcance" name="alcance">
+                        <field name="statement_date"/>
+                        <field name="report_scope" widget="radio"
+                               attrs="{'invisible': [('can_see_all', '=', False)], 'readonly': [('can_see_all', '=', False)]}"/>
+                        <div class="text-muted"
+                             attrs="{'invisible': [('can_see_all', '=', True)]}">
+                            <i class="fa fa-lock me-1"/>Solo tus propios clientes
+                        </div>
+                        <field name="salesperson_id"
+                               options="{'no_create': True, 'no_open': True}"
+                               attrs="{'invisible': [('report_scope', '!=', 'single')], 'required': [('report_scope', '=', 'single')], 'readonly': [('can_see_all', '=', False)]}"/>
+                    </group>
+                    <group string="Filtros" name="filtros">
+                        <field name="only_overdue"/>
+                        <field name="min_overdue_days" placeholder="0 = sin filtro"/>
+                        <field name="order_by"/>
+                    </group>
+                </group>
+                <group string="Formato de salida" name="salida">
+                    <field name="output_format" widget="radio"
+                           options="{'horizontal': true}" nolabel="1"/>
+                </group>
+                <footer>
+                    <button name="action_generate" string="Generar reporte"
+                            type="object" class="btn-primary"
+                            icon="fa-download"/>
+                    <button string="Cancelar" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_account_statement_wizard" model="ir.actions.act_window">
+        <field name="name">Estado de cuenta de clientes</field>
+        <field name="res_model">account.statement.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="menu_account_statement_report"
+              name="Estado de cuenta de clientes"
+              parent="account.menu_finance_reports"
+              action="action_account_statement_wizard"
+              sequence="99"/>
+
+</odoo>


### PR DESCRIPTION
Descripción:
## Cambios

Incorpora a `16.0` el módulo **account_statement_report** (estado de cuenta de
clientes) con dos ajustes solicitados, ya probados en 16.0-QA:

### 1) Semáforo de atraso de 2 colores
- 🟡 Amarillo (`#FFEB9C`): 1–14 días de atraso
- 🔴 Rojo (`#FFC7CE`): 15 días o más

Antes eran 3 tramos (se eliminó el naranja 31–60). Aplicado en la lógica,
la leyenda del PDF y el formato Excel.

### 2) Reporte por cliente (además de por vendedor)
- Nuevo selector **"Agrupar"**: *Por vendedor* (comportamiento actual) o
  *Por cliente* (agrupa por cliente y, dentro, por vendedor).
- Nuevo filtro opcional **Cliente** para limitar el reporte a un solo cliente.
- Encabezados, columnas y subtotales (PDF y Excel) usan etiquetas dinámicas
  según el agrupamiento elegido.

## Notas
- El módulo no existía en `16.0`; el PR trae 3 commits (`[ADD]`, `[REF]`, `[IMP]`),
  todos sobre `account_statement_report/`.
- Tras hacer merge, **actualizar el módulo** (`-u account_statement_report`) para
  que se creen las columnas nuevas (`group_by`, `partner_id`).
- El día 15 de atraso cuenta como rojo (rojo = 15 o más).

Un par de cosas:
- Si en este repo usan que el PR apunte a otra rama de integración en vez de 16.0 directo, cambia la base del PR a la que corresponda.
- La nota de "actualizar el módulo" es importante: es justo el error UndefinedColumn que te salió antes, así evitas que se repita en producción.